### PR TITLE
chore: rename endpoint to ci optimizer

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -13,7 +13,7 @@ TIMEOUT="${BUILDKITE_PLUGIN_GRAPHITE_CI_TIMEOUT:-30}"
 BODY_FILE="$(mktemp)"
 
 RESPONSE_CODE=$(curl -s -o "$BODY_FILE" -w "%{response_code}" \
-  "$ENDPOINT/api/v1/ci" \
+  "$ENDPOINT/api/v1/ci/optimizer" \
   -m $TIMEOUT \
   -X POST \
   -H "Accept: application/json" \


### PR DESCRIPTION
Rename endpoint to ci/optimizer.

Prefer the more specific name in case we want to make more endpoints in the future.