### PR TITLE
Annotate build page when CI is optimized

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -54,6 +54,9 @@ fi
 
 SHOULD_SKIP=$(jq .skip $BODY_FILE)
 
-if [ $SHOULD_SKIP = "true" ]; then 
+if [ $SHOULD_SKIP = "true" ]; then
+  buildkite-agent annotate ":graphite: This PR is in the middle of a [stack](https://stacking.dev)
+                            and will not run CI until it configured to do so,
+                            or is manually triggered." --style "info" --context "graphite" --job $BUILDKITE_JOB_ID
   buildkite-agent pipeline upload "$DIR/../pipelines/empty.yml" --replace
 fi


### PR DESCRIPTION
Show this blue info banner when the plugin skips CI

<img width="1253" alt="Screenshot 2024-04-24 at 11 25 34" src="https://github.com/withgraphite/graphite-ci-buildkite-plugin/assets/778344/97134f11-b2ec-41c8-b5f5-d0e1bd058d26">
